### PR TITLE
Only trigger load when the element is visible

### DIFF
--- a/jquery.infinite-scroll-helper.js
+++ b/jquery.infinite-scroll-helper.js
@@ -104,7 +104,7 @@
 			elementBottom = this.element.height() + contentOffset.top,
 			scrollBottom = this.win.scrollTop() + this.win.height() + this.options.bottomBuffer;
 
-      	return (!this.loading && scrollBottom >= elementBottom);
+      	return (!this.loading && scrollBottom >= elementBottom && this.element.is(':visible'));
 	}
 
 	/*-------------------------------------------- */


### PR DESCRIPTION
Useful when using a class to show/hide different lists on the same page. Doesn't make much sense to scroll anything with "display: none" anyway :)
