### PR TITLE
Stop interval timer after destroying instance.

### DIFF
--- a/jquery.infinite-scroll-helper.js
+++ b/jquery.infinite-scroll-helper.js
@@ -81,7 +81,9 @@
   				
   				self.doneLoadingInt = setInterval( 
   					function() {
-      					if (self.options.doneLoading(self.pageCount)) {
+  					if (self.options.doneLoading === null) {
+      						clearInterval(self.doneLoadingInt);
+  					} else if (self.options.doneLoading(self.pageCount)) {
       						clearInterval(self.doneLoadingInt);
       						self.loading = false;
       						self.element.removeClass(self.options.loadingClass);


### PR DESCRIPTION
If `self.options.doneLoading === null` it looks like the helper has been destroyed, and the timer can safely be cleared.
