### PR TITLE
"refresh" method

### DIFF
--- a/jquery.infinite-scroll-helper.js
+++ b/jquery.infinite-scroll-helper.js
@@ -254,7 +254,17 @@
 		clearInterval(this.doneLoadingInt);
 		this.destroyed = true;
 	};
-
+	
+	/**
+	 * Refresh the plugin instance
+	 * You can call this function instead of destroying/creating new instance if user clicks "go back" button.
+	 * @public
+	 */
+	Plugin.prototype.refresh = function() {
+		this._addListeners();
+		this.destroyed = false;
+	};	
+	
 	/*-------------------------------------------- */
 	/** Helpers */
 	/*-------------------------------------------- */


### PR DESCRIPTION
When user goes away from the page with infinite scroll and then goes back create/destroy/create doesn't work. So i made "refresh" method to return infinite scroll back to life with create/refresh.
You should attach create and refresh to "pageshow" event.
