### PR TITLE
Method to set the pageCount

### DIFF
--- a/jquery.infinite-scroll-helper.js
+++ b/jquery.infinite-scroll-helper.js
@@ -285,6 +285,14 @@
 	/*-------------------------------------------- */
 
 	/**
+	 * Set the pageCount
+	 * @public
+	 */
+	Plugin.prototype.setPageCount = function(p) {
+		this.pageCount = p;
+	};
+	
+	/**
 	 * Destroys the plugin instance
 	 * @public
 	 */


### PR DESCRIPTION
This method can be used to set programmatically the current pageCount.

Example to set the pageCount to 0:
$('#my-element-to-watch').infiniteScrollHelper('setPageCount', 0);


This is especially useful when it is needed to refresh the instance because the content changed by setting the pageCount to 0 (this cleaner that destroying the current instance and re-initializing a new one).